### PR TITLE
build-helper-maven-plugin to add target/generated-sources/annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,25 @@
                 </configuration>
             </plugin>
             <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>build-helper-maven-plugin</artifactId>
+              <version>1.10</version>
+              <executions>
+                <execution>
+                  <id>add-source</id>
+                  <phase>generate-sources</phase>
+                  <goals>
+                    <goal>add-source</goal>
+                  </goals>
+                  <configuration>
+                    <sources>
+                      <source>${project.build.directory}/generated-sources/annotations</source>
+                    </sources>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Without doing this, one cannot run e.g. MainTest within Eclipse easily

Signed-off-by: Michael Vorburger vorburger@redhat.com
