### PR TITLE
Use maven-processor-plugin instead of maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,16 +40,6 @@
 
     <dependencies>
         <!--
-            JBoss Tools
-        -->
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <version>1.0.0.Final</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!--
             JBoss Logging
         -->
         <dependency>
@@ -78,12 +68,43 @@
     <build>
         <plugins>
             <plugin>
+              <groupId>org.bsc.maven</groupId>
+              <artifactId>maven-processor-plugin</artifactId>
+              <version>3.1.0</version>
+              <configuration>
+                <options>
+                  <generatedTranslationFilesPath>${project.build.directory}/generated-translation-files</generatedTranslationFilesPath>
+                </options>
+              </configuration>
+              <executions>                         <!-- Run annotation processors on src/main/java sources -->
+                <execution>
+                  <id>process</id>
+                  <goals>
+                    <goal>process</goal>
+                  </goals>
+                  <phase>generate-sources</phase>
+                </execution>                         <!-- Run annotation processors on src/test/java sources -->
+                <execution>
+                  <id>process-test</id>
+                  <goals>
+                    <goal>process-test</goal>
+                  </goals>
+                  <phase>generate-test-sources</phase>
+                </execution>
+              </executions>
+              <dependencies>
+                <dependency>
+                  <groupId>org.jboss.logging</groupId>
+                  <artifactId>jboss-logging-processor</artifactId>
+                  <version>1.0.0.Final</version>
+                </dependency>
+              </dependencies>
+            </plugin>  
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerArgument>
-                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
-                    </compilerArgument>
+                    <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This has the advantage that jboss-logging-processor is not on the
project's real classpath.  After all, javac and a myriad of other Maven
build tools (such as other non-APT code generators) are not either, so
why should this be.
